### PR TITLE
Various cleanups

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,10 +3,13 @@ SUBDIRS = . tests
 ACLOCAL_AMFLAGS=-I m4
 
 AM_CPPFLAGS = -I $(top_srcdir)/src -I $(top_srcdir)/src/interpreters -I $(top_srcdir)/src/datasources
-AM_CFLAGS = -std=gnu99 -fstack-protector -Wall -pedantic \
-	-Wstrict-prototypes -Wundef -fno-common \
-	-Wformat -Wformat-security \
-	-Wconversion -Wunused-variable -Wunreachable-code
+AM_CFLAGS = \
+        -fstack-protector -Wall -pedantic \
+        -Wstrict-prototypes -Wundef -fno-common \
+        -Werror-implicit-function-declaration \
+        -Wformat -Wformat-security -Werror=format-security \
+        -Wconversion -Wunused-variable -Wunreachable-code \
+        -Wall -W -std=gnu99
 
 EXTRA_DIST = \
 	LICENSE \

--- a/README
+++ b/README
@@ -43,7 +43,7 @@ a short summary of the key points of that decision are listed below.
 
 Speed is a significant factor. Interpreted languages have come a long
 way and are highly performant, especially if properly used. However,
-theire is a significant cost of provisioning cloud nodes that have
+there is a significant cost of provisioning cloud nodes that have
 increased base storage costs due to the inclusion of libraries of
 interpreted languages. Since we expect people to prefer cloud nodes are
 minimal in size, having interpreted language libraries just for the

--- a/src/async_task.c
+++ b/src/async_task.c
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/async_task.h
+++ b/src/async_task.h
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/ccmodules.h
+++ b/src/ccmodules.h
@@ -1,23 +1,23 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Auke-jan H. Kok <auke-jan.h.kok@intel.com>
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/ccmodules/envar.c
+++ b/src/ccmodules/envar.c
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/ccmodules/fbootcmd.c
+++ b/src/ccmodules/fbootcmd.c
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/ccmodules/groups.c
+++ b/src/ccmodules/groups.c
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/ccmodules/hostname.c
+++ b/src/ccmodules/hostname.c
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/ccmodules/package_upgrade.c
+++ b/src/ccmodules/package_upgrade.c
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Auke-jan H. Kok <auke-jan.h.kok@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/ccmodules/packages.c
+++ b/src/ccmodules/packages.c
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Auke-jan H. Kok <auke-jan.h.kok@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/ccmodules/runcmd.c
+++ b/src/ccmodules/runcmd.c
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/ccmodules/service.c
+++ b/src/ccmodules/service.c
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Auke-jan H. Kok <auke-jan.h.kok@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/ccmodules/ssh_authorized_keys.c
+++ b/src/ccmodules/ssh_authorized_keys.c
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/ccmodules/users.c
+++ b/src/ccmodules/users.c
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/ccmodules/write_files.c
+++ b/src/ccmodules/write_files.c
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/datasources.h
+++ b/src/datasources.h
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/datasources/openstack.c
+++ b/src/datasources/openstack.c
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/datasources/openstack.h
+++ b/src/datasources/openstack.h
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Auke-jan H. Kok <auke-jan.h.kok@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/debug.h
+++ b/src/debug.h
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Auke-jan H. Kok <auke-jan.h.kok@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/default_user.h
+++ b/src/default_user.h
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/disk.c
+++ b/src/disk.c
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/disk.h
+++ b/src/disk.h
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/handlers.h
+++ b/src/handlers.h
@@ -1,23 +1,23 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Auke-jan H. Kok <auke-jan.h.kok@intel.com>
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/interpreters.h
+++ b/src/interpreters.h
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/interpreters/cloud_config.c
+++ b/src/interpreters/cloud_config.c
@@ -1,23 +1,23 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Auke-jan H. Kok <auke-jan.h.kok@intel.com>
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/interpreters/cloud_config.h
+++ b/src/interpreters/cloud_config.h
@@ -1,23 +1,23 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Auke-jan H. Kok <auke-jan.h.kok@intel.com>
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/interpreters/shell_script.c
+++ b/src/interpreters/shell_script.c
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/json.c
+++ b/src/json.c
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/json.h
+++ b/src/json.h
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/lib.c
+++ b/src/lib.c
@@ -250,7 +250,7 @@ bool write_ssh_keys(const GString* data, const gchar* username) {
 	GString* ssh_keys = NULL;
 	struct passwd pwd;
 	struct passwd* pwd_result;
-	char* pwd_buf;
+	char* pwd_buf = NULL;
 	long int pwd_bufsize;
 	struct stat st;
 
@@ -322,6 +322,8 @@ bool write_ssh_keys(const GString* data, const gchar* username) {
 			LOG(MOD "Cannot change the owner and group of %s.\n", auth_keys_file);
 			return false;
 		}
+	} else {
+		free(pwd_buf);
 	}
 
 	return true;

--- a/src/lib.c
+++ b/src/lib.c
@@ -1,23 +1,23 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Auke-jan H. Kok <auke-jan.h.kok@intel.com>
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/lib.h
+++ b/src/lib.h
@@ -1,23 +1,23 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Auke-jan H. Kok <auke-jan.h.kok@intel.com>
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/main.c
+++ b/src/main.c
@@ -1,23 +1,23 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Auke-jan H. Kok <auke-jan.h.kok@intel.com>
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the
@@ -220,7 +220,7 @@ int main(int argc, char *argv[]) {
 	}
 
 #ifdef HAVE_CONFIG_H
-	LOG("clr-cloud-init version: %s\n", PACKAGE_VERSION);
+	LOG("micro-config-drive version: %s\n", PACKAGE_VERSION);
 #endif /* HAVE_CONFIG_H */
 
 	/* at one point in time this should likely be a fatal error */

--- a/src/userdata.c
+++ b/src/userdata.c
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/src/userdata.h
+++ b/src/userdata.h
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -46,7 +46,7 @@ lib_test_LDADD = libtest.la $(COMMON_LDADD)
 TESTS += lib_test
 
 userdata_test_SOURCES = userdata_test.c
-userdata_test_CFLAGS = $(COMMON_CFLAGS)
+userdata_test_CFLAGS = $(COMMON_CFLAGS) $(AM_CFLAGS)
 userdata_test_LDADD = libtest.la $(COMMON_LDADD)
 TESTS += userdata_test
 

--- a/tests/lib_test.c
+++ b/tests/lib_test.c
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the

--- a/tests/userdata_test.c
+++ b/tests/userdata_test.c
@@ -1,22 +1,22 @@
 /***
- Copyright (C) 2015 Intel Corporation
+ Copyright © 2015 Intel Corporation
 
  Author: Julio Montes <julio.montes@intel.com>
 
- This file is part of clr-cloud-init.
+ This file is part of micro-config-drive.
 
- clr-cloud-init is free software: you can redistribute it and/or modify
+ micro-config-drive is free software: you can redistribute it and/or modify
  it under the terms of the GNU General Public License as published by
  the Free Software Foundation, either version 3 of the License, or
  (at your option) any later version.
 
- clr-cloud-init is distributed in the hope that it will be useful,
+ micro-config-drive is distributed in the hope that it will be useful,
  but WITHOUT ANY WARRANTY; without even the implied warranty of
  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  GNU General Public License for more details.
 
  You should have received a copy of the GNU General Public License
- along with clr-cloud-init. If not, see <http://www.gnu.org/licenses/>.
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
 
  In addition, as a special exception, the copyright holders give
  permission to link the code of portions of this program with the


### PR DESCRIPTION
Various cleanups/fix-ups needed in the codebase.

Note that I originally intended to include a new `make coverage` target, but the way in which the `make check` target is actually handled as a SUBDIR breaks `distcheck` by leaving stray `*.gcno` files. This should ideally be changes to a common `.a` to be shared among the test suite and the main binary in future, with a top-level `check`, `coverage`, and `check-valgrind` (Out of scope for this PR): https://github.com/ikeydoherty/micro-config-drive/commit/62f215cd23ec4ee6f723eceedf661d04633d686c
