### PR TITLE
Add Tencent cloud support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ autom4te.cache
 ucd
 ucd-aws
 ucd-oci
+ucd-tct
 compile
 config.*
 configure

--- a/Makefile.am
+++ b/Makefile.am
@@ -18,6 +18,7 @@ EXTRA_DIST = \
 	docs/ucd.1.md \
 	docs/ucd-aws.1.md \
 	docs/ucd-oci.1.md \
+	docs/ucd-tct.1.md \
 	docs/cloud-config.5.md
 
 DISTCHECK_CONFIGURE_FLAGS =  \
@@ -27,12 +28,14 @@ dist_man_MANS = \
 	docs/ucd.1 \
 	docs/ucd-aws.1 \
 	docs/ucd-oci.1 \
+	docs/ucd-tct.1 \
 	docs/cloud-config.5
 
 bin_PROGRAMS = \
 	ucd \
 	ucd-aws \
-	ucd-oci
+	ucd-oci \
+	ucd-tct
 
 ucd_SOURCES = \
 	src/ccmodules.h \
@@ -75,6 +78,9 @@ ucd_aws_SOURCES = \
 ucd_oci_SOURCES = \
 	src/ucd-oci.c
 
+ucd_tct_SOURCES = \
+	src/ucd-tct.c
+
 if ENABLE_WERROR
 AM_CFLAGS += -Werror
 endif
@@ -90,9 +96,11 @@ ucd_aws_CFLAGS = $(AM_CFLAGS)
 
 ucd_oci_CFLAGS = $(AM_CFLAGS)
 
+ucd_tct_CFLAGS = $(AM_CFLAGS)
+
 SYSTEMD_DIR=$(prefix)/lib/systemd/system/
 systemdsystemunitdir = @SYSTEMD_SYSTEMUNITDIR@
-systemdsystemunit_DATA = data/ucd.service data/ucd-aws.service data/ucd-oci.service
+systemdsystemunit_DATA = data/ucd.service data/ucd-aws.service data/ucd-oci.service data/ucd-tct.service
 
 systemdsystemunit-install-local:
 	mkdir -p $(DESTDIR)$(systemdsystemunitdir)/multi-user.target.wants/
@@ -111,6 +119,8 @@ docs/ucd-aws.1: docs/ucd-aws.1.md
 	ronn -r --pipe < docs/ucd-aws.1.md > docs/ucd-aws.1
 docs/ucd-oci.1: docs/ucd-oci.1.md
 	ronn -r --pipe < docs/ucd-oci.1.md > docs/ucd-oci.1
+docs/ucd-tct.1: docs/ucd-tct.1.md
+	ronn -r --pipe < docs/ucd-tct.1.md > docs/ucd-tct.1
 docs/cloud-config.5: docs/cloud-config.5.md
 	ronn -r --pipe < docs/cloud-config.5.md > docs/cloud-config.5
-docs: docs/ucd.1 docs/ucd-aws.1 docs/ucd-oci.1 docs/cloud-config.5
+docs: docs/ucd.1 docs/ucd-aws.1 docs/ucd-oci.1 docs/ucd-tct.1 docs/cloud-config.5

--- a/configure.ac
+++ b/configure.ac
@@ -9,7 +9,8 @@ AC_CONFIG_FILES([Makefile
 		tests/Makefile
 		data/ucd.service
 		data/ucd-aws.service
-                data/ucd-oci.service])
+		data/ucd-oci.service
+		data/ucd-tct.service])
 AC_CONFIG_HEADERS([config.h])
 
 LT_INIT

--- a/data/ucd-tct.service.in
+++ b/data/ucd-tct.service.in
@@ -1,0 +1,17 @@
+[Unit]
+Description=micro-config-drive job for Tencent
+After=network.target systemd-networkd.service
+Wants=local-fs.target sshd.service sshd-keygen.service
+ConditionPathExists=!/var/lib/cloud/tct-user-data
+
+[Service]
+Type=oneshot
+ExecStart=@prefix@/bin/ucd-tct
+RemainAfterExit=yes
+TimeoutSec=0
+
+# Output needs to appear in instance console output
+StandardOutput=journal+console
+
+[Install]
+WantedBy=multi-user.target

--- a/docs/ucd-tct.1
+++ b/docs/ucd-tct.1
@@ -1,0 +1,38 @@
+.\" generated with Ronn/v0.7.3
+.\" http://github.com/rtomayko/ronn/tree/0.7.3
+.
+.TH "UCD\-TCT" "1" "July 2019" "" ""
+.
+.SH "NAME"
+\fBucd\-tct\fR \- Fetch ssh public key from TencentYun meta\-service
+.
+.SH "SYNOPSIS"
+\fB/usr/bin/ucd\-tct\fR
+.
+.SH "DESCRIPTION"
+\fBucd\-tct\fR a helper program that fetches the SSH pubkey provided to the cloud instance\. After fetching the data, ucd\-tct creates a \fB#cloud\-config\fR text block and passes the output to \fBucd\fR(1) for processing/execution\.
+.
+.SH "OPTIONS"
+\fBucd\-tct\fR has no configurable options\.
+.
+.SH "EXIT STATUS"
+On success, 0 is returned, a non\-zero failure code otherwise\. The exit code returned may be the exit code of the subsequent \fBucd\fR program execution\.
+.
+.SH "COPYRIGHT"
+.
+.IP "\(bu" 4
+Copyright (C) 2019 Intel Corporation, License: CC\-BY\-SA\-3\.0
+.
+.IP "" 0
+.
+.SH "SEE ALSO"
+\fBucd\fR(1)
+.
+.SH "NOTES"
+Creative Commons Attribution\-ShareAlike 3\.0 Unported
+.
+.IP "\(bu" 4
+http://creativecommons\.org/licenses/by\-sa/3\.0/
+.
+.IP "" 0
+

--- a/docs/ucd-tct.1.md
+++ b/docs/ucd-tct.1.md
@@ -1,0 +1,37 @@
+ucd-tct(1) -- Fetch ssh public key from TencentYun meta-service
+========================================================
+
+## SYNOPSIS
+
+`/usr/bin/ucd-tct`
+
+## DESCRIPTION
+
+`ucd-tct` a helper program that fetches the SSH pubkey provided to the
+cloud instance. After fetching the data, ucd-tct creates a
+`#cloud-config` text block and passes the output to `ucd`(1) for
+processing/execution.
+
+## OPTIONS
+
+`ucd-tct` has no configurable options.
+
+## EXIT STATUS
+
+On success, 0 is returned, a non-zero failure code otherwise. The exit
+code returned may be the exit code of the subsequent `ucd` program
+execution.
+
+## COPYRIGHT
+
+ * Copyright (C) 2019 Intel Corporation, License: CC-BY-SA-3.0
+
+## SEE ALSO
+
+`ucd`(1)
+
+## NOTES
+
+Creative Commons Attribution-ShareAlike 3.0 Unported
+
+ * http://creativecommons.org/licenses/by-sa/3.0/

--- a/src/ucd-tct.c
+++ b/src/ucd-tct.c
@@ -1,0 +1,220 @@
+
+/***
+ Copyright © 2019 Intel Corporation
+
+ Author: Jing Wang <jing.j.wang@intel.com>
+
+ This file is part of micro-config-drive.
+
+ micro-config-drive is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ micro-config-drive is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with micro-config-drive. If not, see <http://www.gnu.org/licenses/>.
+
+ In addition, as a special exception, the copyright holders give
+ permission to link the code of portions of this program with the
+ OpenSSL library under certain conditions as described in each
+ individual source file, and distribute linked combinations
+ including the two.
+ You must obey the GNU General Public License in all respects
+ for all of the code used other than OpenSSL.  If you modify
+ file(s) with this exception, you may extend this exception to your
+ version of the file(s), but you are not obligated to do so.  If you
+ do not wish to do so, delete this exception statement from your
+ version.  If you delete this exception statement from all source
+ files in the program, then also delete it here.
+***/
+
+#ifdef HAVE_CONFIG_H
+	#include "config.h"
+#endif
+
+#include <unistd.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stdio.h>
+#include <stdbool.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+#include <arpa/inet.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <netdb.h>
+#include <fcntl.h>
+#include <time.h>
+#include <errno.h>
+
+#define FAIL(err) do { perror(err); exit(EXIT_FAILURE); } while(0)
+
+#define TCT_USER_DATA_PATH "/var/lib/cloud"
+#define TCT_USER_DATA "tct-user-data"
+#define TCT_DN "metadata.tencentyun.com"
+
+#define TCT_REQUEST_SSHKEY "GET /latest/meta-data/public-keys/0/openssh-key HTTP/1.0\r\nhost: " TCT_DN "\r\nConnection: keep-alive\r\n\r\n"
+#define CLOUD_CONFIG_TCT_HEADER \
+"#cloud-config\n" \
+"users:\n" \
+"  - name: tencent\n"\
+"    groups: wheelnopw\n"\
+"    ssh-authorized-keys:\n"\
+"      - "
+
+/*
+ * parse_headers:
+ * f: file descriptor for input (stream)
+ * *cl: output content-length
+ * return values: status code
+ * - 0: an actual error occurred.
+ * - 1: parsed headers OK in full, ready to read content.
+ * - 2: non-200 exit status, but no error in conversation.
+ */
+static int parse_headers(FILE *f, long int *cl)
+{
+	for (;;) {
+		char buf[512];
+		char *r = fgets(buf, sizeof(buf), f);
+		perror(buf);
+		if (!r) {
+			return 0;
+		}
+		if (strncmp(buf, "\r\n", 2) == 0) {
+			/* end of headers */
+			break;
+		} else if (strncmp(buf, "Content-Length:", 15) == 0) {
+			/* content length */
+			*cl = strtol(&buf[16], NULL, 10);
+			if (errno == EINVAL || errno == ERANGE) {
+				return 0;
+			}
+		} else if (strstr(buf, "404 Not Found")) {
+			return 2;
+		} else if (strncmp(buf, "HTTP/1.1", 8) == 0) {
+			long int status = strtol(&buf[8], NULL, 10);
+			if (errno == EINVAL || errno == ERANGE) {
+				return 0;
+			}
+			/* fail if non-200 exit code */
+			if (status < 200 || status >= 299 ) {
+				return 2;
+			}
+		}
+	}
+	return 1;
+}
+
+int main(void) {
+	int sockfd;
+
+	sockfd = socket(AF_INET, SOCK_STREAM, 0);
+	if (sockfd < 0) {
+		FAIL("socket()");
+	}
+
+	struct sockaddr_in server;
+	memset(&server, 0, sizeof(struct sockaddr_in));
+	server.sin_family = AF_INET;
+
+	struct timespec ts;
+	ts.tv_sec = 0;
+	ts.tv_nsec = 50000000;
+
+	/* Get host ip from name */
+	struct hostent *he = NULL;
+	for (;;) {
+		int n = 0;
+		he = gethostbyname(TCT_DN);
+		if (he != NULL) {
+			break;
+		}
+		nanosleep(&ts, NULL);
+		if (++n > 200) { /* 10 secs */
+			FAIL("timeout in gethostbyname()");
+		}
+	}
+
+	server.sin_addr.s_addr = *((unsigned int *)he->h_addr);
+	server.sin_port = htons(80);
+
+	for (;;) {
+		int n = 0;
+		int r = connect(sockfd, (struct sockaddr *)&server, sizeof(server));
+		if (r == 0) {
+			break;
+		}
+		if ((errno != EAGAIN) && (errno != ENETUNREACH) && (errno != ETIMEDOUT)) {
+			FAIL("connect()");
+		}
+		nanosleep(&ts, NULL);
+		if (++n > 200) { /* 10 secs */
+			FAIL("timeout in connect()");
+		}
+	}
+
+	/* First, request the OpenSSH pubkey */
+	char *request = TCT_REQUEST_SSHKEY;
+	size_t len = strlen(request);
+
+	if (write(sockfd, request, len) < (ssize_t)len) {
+		close(sockfd);
+		FAIL("write()");
+	}
+
+	FILE *f = fdopen(sockfd, "r");
+	if (!f) {
+		close(sockfd);
+		FAIL("fdopen()");
+	}
+
+	long int cl;
+	int result = parse_headers(f, &cl);
+	if (result != 1) {
+		close(sockfd);
+		FAIL("parse_headers()");
+	}
+	close(sockfd);
+
+	int out;
+	(void) mkdir(TCT_USER_DATA_PATH, 0);
+	(void) unlink(TCT_USER_DATA_PATH "/" TCT_USER_DATA);
+	out = open(TCT_USER_DATA_PATH "/" TCT_USER_DATA, O_WRONLY | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR);
+	if (out < 0) {
+		FAIL("open()");
+	}
+
+	/* Insert cloud-config header above SSH key. */
+	char *header = CLOUD_CONFIG_TCT_HEADER;
+	len = strlen(header);
+	write(out, header, len);
+
+	for (;;) {
+		if (cl == 0) {
+			break;
+		}
+		char buf[512];
+		fgets(buf, sizeof(buf), f);
+		size_t len = strlen(buf);
+		cl -= (long int)len;
+		if (write(out, buf, len) < (ssize_t)len) {
+			close(out);
+			fclose(f);
+			unlink(TCT_USER_DATA_PATH "/" TCT_USER_DATA);
+			FAIL("write()");
+		}
+	}
+
+	/* cleanup */
+	close(out);
+	fclose(f);
+
+	(void) execl(BINDIR "/ucd", BINDIR "/ucd", "-u",
+			TCT_USER_DATA_PATH "/" TCT_USER_DATA, (char *)NULL);
+	FAIL("exec()");
+}


### PR DESCRIPTION
Enable ucd to support Tencent Cloud environment where meta-data service
is at metadata.tencentyun.com, but not openstack style 169.254.169.254
This commit involves creating a tencent user and provisioning the ssh public
key.
