### PR TITLE
Changed ucd to start after multi-user.target

### DIFF
--- a/data/ucd.service.in
+++ b/data/ucd.service.in
@@ -1,6 +1,6 @@
 [Unit]
 Description=micro-config-drive job
-After=local-fs.target
+After=multi-user.target
 Before=network.target systemd-networkd.service
 Wants=local-fs.target sshd.service sshd-keygen.service
 
@@ -14,4 +14,4 @@ TimeoutSec=0
 StandardOutput=journal+console
 
 [Install]
-WantedBy=multi-user.target
+RequiredBy=multi-user.target


### PR DESCRIPTION
This patch is to require ucd to start and also bring it up later in the boot process.