### PR TITLE
Resolve config drive issue

### DIFF
--- a/data/50-ucd-config-drive.rules
+++ b/data/50-ucd-config-drive.rules
@@ -1,0 +1,7 @@
+KERNEL!="sr[0-9]", GOTO="no_config_drive_end"
+# Import FS info udev
+IMPORT{program}="/sbin/blkid -o udev -p %N"
+ACTION!="add", GOTO="no_config_drive_end"
+SUBSYSTEM=="block", ENV{ID_FS_TYPE}=="iso9660|udf|vfat", ENV{ID_FS_LABEL}=="config-2|CONFIG-2", RUN+="/usr/bin/ucd --user-data-once"
+# Exit
+LABEL="no_config_drive_end"


### PR DESCRIPTION
This PR is to create a udev rule that imports the FS_LABEL so udev can recognize config-2.

Resolves:
https://github.com/clearlinux/micro-config-drive/issues/40